### PR TITLE
Feat/organization resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+# Local files
+.idea
+.tool-versions

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  # Override Devise's after_sign_in_path_for method
+  def after_sign_in_path_for(_resource)
+    create_or_join_organizations_path
+  end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class OrganizationsController < ApplicationController
+  def new
+    @organization = Organization.new
+  end
+
+  def create
+    @organization = Organization.new(organization_params)
+    @organization.invite_code = generate_invite_code
+    if @organization.save
+      flash[:notice] = "Organization created successfully."
+      redirect_to new_organization_path
+    else
+      flash[:alert] = "Error creating organization."
+      render new_organization_path
+    end
+  rescue ActiveRecord::RecordNotUnique
+    flash[:alert] = "Organization name must be unique."
+    redirect_to new_organization_path
+  end
+
+  private
+
+  def organization_params
+    params.require(:organization).permit(:name)
+  end
+
+  def generate_invite_code
+    SecureRandom.hex(10)
+  end
+end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OrganizationsController < ApplicationController
-  before_action :organization, only: %i[show update]
+  before_action :organization, only: %i[show update regenerate_invite_code]
 
   def new
     @organization = Organization.new
@@ -34,6 +34,12 @@ class OrganizationsController < ApplicationController
     redirect_to organization_path(@organization)
   rescue ActiveRecord::RecordNotUnique
     flash[:alert] = "Organization name must be unique."
+    redirect_to organization_path(@organization)
+  end
+
+  def regenerate_invite_code
+    @organization.update(invite_code: generate_invite_code)
+    flash[:notice] = "Invite code regenerated successfully."
     redirect_to organization_path(@organization)
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 class OrganizationsController < ApplicationController
-  before_action :organization, only: %i[show]
+  before_action :organization, only: %i[show update]
 
   def new
     @organization = Organization.new
   end
 
   def show
-    organization
   end
 
   def create
@@ -24,6 +23,18 @@ class OrganizationsController < ApplicationController
   rescue ActiveRecord::RecordNotUnique
     flash[:alert] = "Organization name must be unique."
     redirect_to new_organization_path
+  end
+
+  def update
+    if @organization.update(organization_params)
+      flash[:notice] = "Organization updated successfully."
+    else
+      flash[:alert] = "Error updating organization."
+    end
+    redirect_to organization_path(@organization)
+  rescue ActiveRecord::RecordNotUnique
+    flash[:alert] = "Organization name must be unique."
+    redirect_to organization_path(@organization)
   end
 
   private

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OrganizationsController < ApplicationController
-  before_action :organization, only: %i[show update regenerate_invite_code]
+  before_action :set_organization, only: %i[show update regenerate_invite_code]
 
   def show; end
 
@@ -11,48 +11,35 @@ class OrganizationsController < ApplicationController
 
   def create
     @organization = Organization.new(organization_params)
-    @organization.invite_code = generate_invite_code
     if @organization.save
-      flash[:notice] = 'Organization created successfully.'
-      redirect_to new_organization_path
+      redirect_to new_organization_path, notice: 'Organization created successfully.'
     else
-      flash[:alert] = 'Error creating organization.'
-      render new_organization_path
+      flash[:alert] = @organization.errors.full_messages.to_sentence
+      redirect_to new_organization_path
     end
-  rescue ActiveRecord::RecordNotUnique
-    flash[:alert] = 'Organization name must be unique.'
-    redirect_to new_organization_path
   end
 
   def update
     if @organization.update(organization_params)
-      flash[:notice] = 'Organization updated successfully.'
+      redirect_to organization_path(@organization), notice: 'Organization updated successfully.'
     else
-      flash[:alert] = 'Error updating organization.'
+      flash[:alert] = @organization.errors.full_messages.to_sentence
+      redirect_to organization_path(@organization)
     end
-    redirect_to organization_path(@organization)
-  rescue ActiveRecord::RecordNotUnique
-    flash[:alert] = 'Organization name must be unique.'
-    redirect_to organization_path(@organization)
   end
 
   def regenerate_invite_code
-    @organization.update(invite_code: generate_invite_code)
-    flash[:notice] = 'Invite code regenerated successfully.'
-    redirect_to organization_path(@organization)
+    @organization.regenerate_invite_code
+    redirect_to organization_path(@organization), notice: 'Invite code regenerated successfully.'
   end
 
   private
 
-  def organization
-    @organization ||= Organization.find(params[:id])
+  def set_organization
+    @organization = Organization.find(params[:id])
   end
 
   def organization_params
     params.require(:organization).permit(:name)
-  end
-
-  def generate_invite_code
-    SecureRandom.hex(10)
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class OrganizationsController < ApplicationController
+  before_action :authenticate_panelist!
   before_action :set_organization, only: %i[show update regenerate_invite_code]
 
   def show; end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class OrganizationsController < ApplicationController
+  before_action :organization, only: %i[show]
+
   def new
     @organization = Organization.new
+  end
+
+  def show
+    organization
   end
 
   def create
@@ -21,6 +27,10 @@ class OrganizationsController < ApplicationController
   end
 
   private
+
+  def organization
+    @organization ||= Organization.find(params[:id])
+  end
 
   def organization_params
     params.require(:organization).permit(:name)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,43 +3,42 @@
 class OrganizationsController < ApplicationController
   before_action :organization, only: %i[show update regenerate_invite_code]
 
+  def show; end
+
   def new
     @organization = Organization.new
-  end
-
-  def show
   end
 
   def create
     @organization = Organization.new(organization_params)
     @organization.invite_code = generate_invite_code
     if @organization.save
-      flash[:notice] = "Organization created successfully."
+      flash[:notice] = 'Organization created successfully.'
       redirect_to new_organization_path
     else
-      flash[:alert] = "Error creating organization."
+      flash[:alert] = 'Error creating organization.'
       render new_organization_path
     end
   rescue ActiveRecord::RecordNotUnique
-    flash[:alert] = "Organization name must be unique."
+    flash[:alert] = 'Organization name must be unique.'
     redirect_to new_organization_path
   end
 
   def update
     if @organization.update(organization_params)
-      flash[:notice] = "Organization updated successfully."
+      flash[:notice] = 'Organization updated successfully.'
     else
-      flash[:alert] = "Error updating organization."
+      flash[:alert] = 'Error updating organization.'
     end
     redirect_to organization_path(@organization)
   rescue ActiveRecord::RecordNotUnique
-    flash[:alert] = "Organization name must be unique."
+    flash[:alert] = 'Organization name must be unique.'
     redirect_to organization_path(@organization)
   end
 
   def regenerate_invite_code
     @organization.update(invite_code: generate_invite_code)
-    flash[:notice] = "Invite code regenerated successfully."
+    flash[:notice] = 'Invite code regenerated successfully.'
     redirect_to organization_path(@organization)
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -4,6 +4,8 @@ class OrganizationsController < ApplicationController
   before_action :authenticate_panelist!
   before_action :set_organization, only: %i[show update regenerate_invite_code]
 
+  def create_or_join; end
+
   def show; end
 
   def new

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -12,7 +12,7 @@ class OrganizationsController < ApplicationController
   def create
     @organization = Organization.new(organization_params)
     if @organization.save
-      redirect_to new_organization_path, notice: 'Organization created successfully.'
+      redirect_to organization_path(@organization), notice: 'Organization created successfully.'
     else
       flash[:alert] = @organization.errors.full_messages.to_sentence
       redirect_to new_organization_path

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -12,7 +12,7 @@ class OrganizationsController < ApplicationController
   def create
     @organization = Organization.new(organization_params)
     if @organization.save
-      redirect_to organization_path(@organization), notice: 'Organization created successfully.'
+      redirect_to organization_path(@organization), notice: I18n.t('organizations.create.success')
     else
       flash[:alert] = @organization.errors.full_messages.to_sentence
       redirect_to new_organization_path
@@ -21,7 +21,7 @@ class OrganizationsController < ApplicationController
 
   def update
     if @organization.update(organization_params)
-      redirect_to organization_path(@organization), notice: 'Organization updated successfully.'
+      redirect_to organization_path(@organization), notice: I18n.t('organizations.update.success')
     else
       flash[:alert] = @organization.errors.full_messages.to_sentence
       redirect_to organization_path(@organization)
@@ -30,7 +30,7 @@ class OrganizationsController < ApplicationController
 
   def regenerate_invite_code
     @organization.regenerate_invite_code
-    redirect_to organization_path(@organization), notice: 'Invite code regenerated successfully.'
+    redirect_to organization_path(@organization), notice: I18n.t('organizations.regenerate_invite_code.success')
   end
 
   private

--- a/app/javascript/controllers/inline_edit_controller.js
+++ b/app/javascript/controllers/inline_edit_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ["name", "form", "input"]
+
+    connect() {
+        this.nameTarget.addEventListener("click", this.edit.bind(this))
+    }
+
+    edit() {
+        this.nameTarget.classList.add("hidden")
+        this.formTarget.classList.remove("hidden")
+        this.inputTarget.focus()
+    }
+
+    save(event) {
+        event.preventDefault()
+        this.formTarget.submit()
+    }
+}

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Organization < ApplicationRecord
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Organization < ApplicationRecord
+  has_many :panelists, dependent: :nullify
+
   validates :name, presence: true, uniqueness: true
   validates :invite_code, presence: true, uniqueness: true, length: { is: 8 }
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,27 @@
 # frozen_string_literal: true
 
 class Organization < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+  validates :invite_code, presence: true, uniqueness: true, length: { is: 8 }
+
+  before_validation :generate_invite_code, on: :create
+
+  def regenerate_invite_code
+    generate_invite_code
+    save!
+  end
+
+  private
+
+  def generate_invite_code
+    assign_random_invite_code while duplicate_or_invalid_invite_code?
+  end
+
+  def assign_random_invite_code
+    self.invite_code = SecureRandom.hex(4)
+  end
+
+  def duplicate_or_invalid_invite_code?
+    invite_code.blank? || Organization.exists?(invite_code: invite_code)
+  end
 end

--- a/app/models/panelist.rb
+++ b/app/models/panelist.rb
@@ -6,5 +6,5 @@ class Panelist < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  belongs_to :organization, dependent: nil
+  belongs_to :organization, dependent: nil, optional: true
 end

--- a/app/models/panelist.rb
+++ b/app/models/panelist.rb
@@ -5,4 +5,6 @@ class Panelist < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  belongs_to :organization, dependent: nil
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,41 +1,49 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Incuhive - Simplify Your Hiring Process</title>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
-  <%= javascript_include_tag 'application' %>
-</head>
 <body class="bg-gray-100">
   <div class="container">
   <div class="bg-gray-800 text-white text-center py-6">
-    <h1 class="text-3xl font-bold">Welcome to Incuhive</h1>
-    <p class="text-lg">Streamlining the hiring process for your team</p>
+    <h1 class="text-3xl font-bold">
+      <%= t('home.heading') %>
+    </h1>
+    <p class="text-lg">
+      <%= t('home.subheading') %>
+    </p>
   </div>
   <div class="text-center py-10 px-4">
-    <h2 class="text-2xl font-semibold mb-4">Why Choose Incuhive?</h2>
-    <p class="text-gray-700 mb-6">Incuhive makes hiring easier with powerful features designed to streamline your hiring process.</p>
+    <h2 class="text-2xl font-semibold mb-4">
+      <%= t('home.heading_why') %>
+    </h2>
+    <p class="text-gray-700 mb-6">
+      <%= t('home.heading_why_answer') %>
+    </p>
     <% if panelist_signed_in? %>
       <div class="bg-gray-800 text-white py-2 px-4 rounded-md">
-        <span class="font-semibold">Welcome</span> <%= current_panelist.email %>
+        <span class="font-semibold">
+          <%= t('home.signed_in.welcome', email: current_panelist.email) %>
+        </span>
       </div>
-      <%= button_to "Sign out", destroy_panelist_session_path, method: :delete, class: "mt-4 bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600" %>
+      <%= button_to t('home.signed_in.buttons.sign_out'), destroy_panelist_session_path, method: :delete, class: "mt-4 bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600" %>
     <% else %>
-      <%= button_to "Get Started", new_panelist_session_path, class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600" %>
+      <%= button_to t('home.not_signed_in.buttons.get_started'), new_panelist_session_path, class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600" %>
     <% end %>
   </div>
   <div class="flex flex-wrap justify-center gap-4 px-4">
     <div class="bg-white rounded-lg shadow-lg p-6 flex flex-col justify-between max-w-sm w-full h-48">
-      <h3 class="text-xl font-semibold text-gray-800 mb-2">Easy to use</h3>
-      <p class="text-gray-600">Anyone can use Incuhive, no training necessary</p>
+      <h3 class="text-xl font-semibold text-gray-800 mb-2">
+        <%= t('home.benefits.easy_to_use') %>
+      </h3>
+      <p class="text-gray-600">
+        <%= t('home.benefits.easy_to_use_desc') %>
+      </p>
     </div>
     <div class="bg-white rounded-lg shadow-lg p-6 flex flex-col justify-between max-w-sm w-full h-48">
-      <h3 class="text-xl font-semibold text-gray-800 mb-2">Excel Interop</h3>
-      <p class="text-gray-600">Incuhive can both import and export to Excel</p>
+      <h3 class="text-xl font-semibold text-gray-800 mb-2">
+        <%= t('home.benefits.excel_interop') %>
+      </h3>
+      <p class="text-gray-600">
+        <%= t('home.benefits.excel_interop_desc') %>
+      </p>
     </div>
   </div>
   </div>
 </body>
-</html>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,16 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
-       <p class="notice"><%= notice %></p>
-       <p class="alert"><%= alert %></p>
+    <main class="container mx-auto mt-28 px-5 flex items-center flex-col">
+      <% if flash[:notice] %>
+        <div class="bg-transparent py-1 px-8 border border-green-600 text-green-600 rounded-md w-fit my-4">
+          <p class="notice"><%= flash[:notice] %></p>
+        </div>
+      <% elsif flash[:alert] %>
+        <div class="bg-transparent py-1 px-8 border border-red-600 text-red-600 rounded-md w-fit my-4">
+          <p class="alert"><%= flash[:alert] %></p>
+        </div>
+      <% end %>
       <%= yield %>
     </main>
   </body>

--- a/app/views/organizations/create_or_join.html.erb
+++ b/app/views/organizations/create_or_join.html.erb
@@ -1,0 +1,25 @@
+<body class="bg-gray-100">
+<div class="container">
+  <section class="w-full bg-gray-100">
+    <div class="bg-gray-800 text-white text-center py-6">
+      <h1 class="text-3xl font-semibold">
+        <%= t('organizations.create_or_join.heading') %>
+      </h1>
+      <p class="text-lg">
+        <%= t('organizations.create_or_join.subheading') %>
+      </p>
+    </div>
+
+    <div class="py-10 px-4">
+      <div class="flex flex-col items-center">
+        <a href="<%= new_organization_path %>" class="w-full md:w-1/2 bg-gray-800 text-white text-center py-4 px-6 rounded-lg mb-4">
+          <%= t('organizations.create_or_join.buttons.create') %>
+        </a>
+        <a href="#" class="w-full md:w-1/2 bg-gray-800 text-white text-center py-4 px-6 rounded-lg">
+          <%= t('organizations.create_or_join.buttons.join') %>
+        </a>
+      </div>
+    </div>
+  </section>
+</div>
+</body>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -18,16 +18,6 @@
       <div class="py-10 px-4">
         <%= form_with model: @organization, local: true do |form| %>
           <div class="flex flex-col gap-4 items-center">
-              <% if flash[:notice] %>
-                <div class="bg-transparent py-1 px-8 border border-green-600 text-green-600 rounded-md w-fit">
-                  <p><%= flash[:notice] %></p>
-                </div>
-              <% elsif flash[:alert] %>
-              <div class="bg-transparent py-1 px-8 border border-red-600 text-red-600 rounded-md w-fit">
-                  <p><%= flash[:alert] %></p>
-                </div>
-              <% end %>
-
             <div>
               <%= form.text_field :name, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3", placeholder: "Name" %>
             </div>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,35 +1,29 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Incuhive - Organization</title>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
-  <%= javascript_include_tag 'application' %>
-</head>
+
 <body class="bg-gray-100">
   <div class="container">
     <section class="w-full bg-gray-100">
       <div class="bg-gray-800 text-white text-center py-6">
-        <h1 class="text-3xl font-semibold">Create Organization</h1>
-        <p class="text-lg">Create a new organization</p>
+        <h1 class="text-3xl font-semibold">
+          <%= t('organizations.new.heading') %>
+        </h1>
+        <p class="text-lg">
+          <%= t('organizations.new.subheading') %>
+        </p>
       </div>
 
       <div class="py-10 px-4">
         <%= form_with model: @organization, local: true do |form| %>
           <div class="flex flex-col gap-4 items-center">
             <div>
-              <%= form.text_field :name, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3", placeholder: "Name" %>
+              <%= form.text_field :name, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3", placeholder: t('organizations.new.fields.placeholders.name') %>
             </div>
 
             <div>
               <%= form.submit "Create", class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500" %>
             </div>
-
           </div>
         <% end %>
       </div>
     </section>
   </div>
 </body>
-</html>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,17 +1,45 @@
-<h1>Create Organization</h1>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Incuhive - Organization</title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
+</head>
+<body class="bg-gray-100">
+  <div class="container">
+    <section class="w-full bg-gray-100">
+      <div class="bg-gray-800 text-white text-center py-6">
+        <h1 class="text-3xl font-semibold">Create Organization</h1>
+        <p class="text-lg">Create a new organization</p>
+      </div>
 
-<% if flash[:notice] %>
-  <p style="color: green;"><%= flash[:notice] %></p>
-<% elsif flash[:alert] %>
-  <p style="color: red;"><%= flash[:alert] %></p>
-<% end %>
+      <div class="py-10 px-4">
+        <%= form_with model: @organization, local: true do |form| %>
+          <div class="flex flex-col gap-4 items-center">
+              <% if flash[:notice] %>
+                <div class="bg-transparent py-1 px-8 border border-green-600 text-green-600 rounded-md w-fit">
+                  <p><%= flash[:notice] %></p>
+                </div>
+              <% elsif flash[:alert] %>
+              <div class="bg-transparent py-1 px-8 border border-red-600 text-red-600 rounded-md w-fit">
+                  <p><%= flash[:alert] %></p>
+                </div>
+              <% end %>
 
-<%= form_with model: @organization, local: true do |form| %>
-  <div>
-    <%= form.label :name %>
-    <%= form.text_field :name %>
+            <div>
+              <%= form.text_field :name, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3", placeholder: "Name" %>
+            </div>
+
+            <div>
+              <%= form.submit "Create", class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500" %>
+            </div>
+
+          </div>
+        <% end %>
+      </div>
+    </section>
   </div>
-  <div>
-    <%= form.submit "Create Organization" %>
-  </div>
-<% end %>
+</body>
+</html>

--- a/app/views/organizations/new.html.erb
+++ b/app/views/organizations/new.html.erb
@@ -1,0 +1,17 @@
+<h1>Create Organization</h1>
+
+<% if flash[:notice] %>
+  <p style="color: green;"><%= flash[:notice] %></p>
+<% elsif flash[:alert] %>
+  <p style="color: red;"><%= flash[:alert] %></p>
+<% end %>
+
+<%= form_with model: @organization, local: true do |form| %>
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+  <div>
+    <%= form.submit "Create Organization" %>
+  </div>
+<% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -20,4 +20,5 @@
 <div>
   <strong>Invite Code:</strong>
   <%= @organization.invite_code %>
+  <%= button_to "Regenerate Invite Code", regenerate_invite_code_organization_path(@organization), method: :patch %>
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,24 +1,61 @@
-<h1>Show Organization</h1>
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Incuhive - Organization</title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= stylesheet_link_tag 'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
+</head>
+<body class="bg-gray-100">
+  <div class="container">
+    <section class="w-full bg-gray-100">
+      <div class="bg-gray-800 text-white text-center py-6">
+        <h1 class="text-3xl font-semibold">Organization</h1>
+        <p class="text-lg">Organization Details</p>
+      </div>
 
-<% if flash[:notice] %>
-  <p style="color: green;"><%= flash[:notice] %></p>
-<% elsif flash[:alert] %>
-  <p style="color: red;"><%= flash[:alert] %></p>
-<% end %>
+      <div class="flex flex-col items-center gap-4 py-4 text-lg">
+        <% if flash[:notice] %>
+          <div class="bg-transparent py-1 px-8 border border-green-600 text-green-600 rounded-md w-fit">
+            <p><%= flash[:notice] %></p>
+          </div>
+        <% elsif flash[:alert] %>
+          <div class="bg-transparent py-1 px-8 border border-red-600 text-red-600 rounded-md w-fit">
+            <p><%= flash[:alert] %></p>
+          </div>
+        <% end %>
 
-<div data-controller="inline-edit">
-  <div>
-    <strong>Name:</strong>
-    <span data-inline-edit-target="name" class="editable"><%= @organization.name %></span>
-    <%= form_with model: @organization, local: true, data: { inline_edit_target: "form" }, class: "hidden" do |form| %>
-      <%= form.text_field :name, data: { inline_edit_target: "input" } %>
-      <%= form.submit "Save", data: { action: "inline-edit#save" } %>
-    <% end %>
+        <div data-controller="inline-edit">
+          <div class="flex flex-row gap-2 items-center">
+            <span class="font-bold">Name:</span>
+            <span data-inline-edit-target="name" class="editable"><%= @organization.name %></span>
+            <%= form_with model: @organization, local: true, data: { inline_edit_target: "form" }, class: "hidden" do |form| %>
+            <%= form.text_field :name, data: { inline_edit_target: "input" }, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3" %>
+            <%= 
+              form.submit "Save", 
+              data: { action: "inline-edit#save" },
+              class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-6 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
+            %>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="flex flex-row gap-2 items-center">
+          <span class="font-bold">Invite Code:</span>
+          <%= @organization.invite_code %>
+        </div>
+
+        <div>
+          <%= 
+            button_to "Regenerate Invite Code", 
+            regenerate_invite_code_organization_path(@organization), 
+            method: :patch, 
+            class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500" 
+          %>
+        </div>
+      </div>
+    </section>
   </div>
-</div>
-
-<div>
-  <strong>Invite Code:</strong>
-  <%= @organization.invite_code %>
-  <%= button_to "Regenerate Invite Code", regenerate_invite_code_organization_path(@organization), method: :patch %>
-</div>
+</body>
+</html>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -8,48 +8,69 @@
   <%= javascript_include_tag 'application' %>
 </head>
 <body class="bg-gray-100">
-  <div class="container">
-    <section class="w-full bg-gray-100">
-      <div class="bg-gray-800 text-white text-center py-6">
-        <h1 class="text-3xl font-semibold">Organization</h1>
-        <p class="text-lg">Organization Details</p>
+<div class="container">
+  <section class="w-full bg-gray-100">
+    <div class="bg-gray-800 text-white text-center py-6">
+      <h1 class="text-3xl font-semibold">Organization</h1>
+      <p class="text-lg">Organization Details</p>
+    </div>
+
+    <div class="flex flex-col items-center gap-4 py-4 text-lg">
+      <div class="bg-transparent py-1 px-8 text-cyan-500 text-sm rounded-md w-fit">
+        <p>* Click on the name to edit.</p>
       </div>
 
-      <div class="flex flex-col items-center gap-4 py-4 text-lg">
-        <div class="bg-transparent py-1 px-8 text-cyan-500 text-sm rounded-md w-fit">
-          <p>* Click on the name to edit.</p>
-        </div>
-
-        <div data-controller="inline-edit">
-          <div class="flex flex-row gap-2 items-center">
-            <span class="font-bold">Name:</span>
-            <span data-inline-edit-target="name" class="editable"><%= @organization.name %></span>
-            <%= form_with model: @organization, local: true, data: { inline_edit_target: "form" }, class: "hidden" do |form| %>
-            <%= form.text_field :name, data: { inline_edit_target: "input" }, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3" %>
-            <%= 
-              form.submit "Save", 
-              data: { action: "inline-edit#save" },
-              class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-6 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
-            %>
-            <% end %>
-          </div>
-        </div>
-
+      <div data-controller="inline-edit">
         <div class="flex flex-row gap-2 items-center">
-          <span class="font-bold">Invite Code:</span>
-          <%= @organization.invite_code %>
-        </div>
-
-        <div>
-          <%= 
-            button_to "Regenerate Invite Code", 
-            regenerate_invite_code_organization_path(@organization), 
-            method: :patch, 
-            class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500" 
-          %>
+          <span class="font-bold">Name:</span>
+          <span data-inline-edit-target="name" class="editable"><%= @organization.name %></span>
+          <%= form_with model: @organization, local: true, data: { inline_edit_target: "form" }, class: "hidden" do |form| %>
+            <%= form.text_field :name, data: { inline_edit_target: "input" }, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3" %>
+            <%=
+              form.submit "Save",
+                          data: { action: "inline-edit#save" },
+                          class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-6 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
+            %>
+          <% end %>
         </div>
       </div>
-    </section>
-  </div>
+
+      <div class="flex flex-row gap-2 items-center">
+        <span class="font-bold">Invite Code:</span>
+        <%= @organization.invite_code %>
+      </div>
+
+      <div>
+        <%=
+          button_to "Regenerate Invite Code",
+                    regenerate_invite_code_organization_path(@organization),
+                    method: :patch,
+                    class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
+        %>
+      </div>
+
+      <!-- Panelists Table -->
+      <div class="w-full mt-8">
+        <h2 class="text-2xl font-semibold mb-4">Panelists</h2>
+        <table class="min-w-full bg-white border border-gray-200 rounded-lg shadow-md">
+          <thead class="bg-gray-200 text-gray-600">
+          <tr>
+            <th class="py-2 px-4 border-b">Email</th>
+            <th class="py-2 px-4 border-b">Created at</th>
+          </tr>
+          </thead>
+          <tbody>
+          <% @organization.panelists.each do |panelist| %>
+            <tr class="hover:bg-gray-100 text-center">
+              <td class="py-2 px-4 border-b"><%= panelist.email %></td>
+              <td class="py-2 px-4 border-b"><%= panelist.created_at.strftime("%B %d, %Y %H:%M") %></td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</div>
 </body>
 </html>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -6,9 +6,15 @@
   <p style="color: red;"><%= flash[:alert] %></p>
 <% end %>
 
-<div>
-  <strong>Name:</strong>
-  <%= @organization.name %>
+<div data-controller="inline-edit">
+  <div>
+    <strong>Name:</strong>
+    <span data-inline-edit-target="name" class="editable"><%= @organization.name %></span>
+    <%= form_with model: @organization, local: true, data: { inline_edit_target: "form" }, class: "hidden" do |form| %>
+      <%= form.text_field :name, data: { inline_edit_target: "input" } %>
+      <%= form.submit "Save", data: { action: "inline-edit#save" } %>
+    <% end %>
+  </div>
 </div>
 
 <div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,0 +1,17 @@
+<h1>Show Organization</h1>
+
+<% if flash[:notice] %>
+  <p style="color: green;"><%= flash[:notice] %></p>
+<% elsif flash[:alert] %>
+  <p style="color: red;"><%= flash[:alert] %></p>
+<% end %>
+
+<div>
+  <strong>Name:</strong>
+  <%= @organization.name %>
+</div>
+
+<div>
+  <strong>Invite Code:</strong>
+  <%= @organization.invite_code %>
+</div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -16,15 +16,9 @@
       </div>
 
       <div class="flex flex-col items-center gap-4 py-4 text-lg">
-        <% if flash[:notice] %>
-          <div class="bg-transparent py-1 px-8 border border-green-600 text-green-600 rounded-md w-fit">
-            <p><%= flash[:notice] %></p>
-          </div>
-        <% elsif flash[:alert] %>
-          <div class="bg-transparent py-1 px-8 border border-red-600 text-red-600 rounded-md w-fit">
-            <p><%= flash[:alert] %></p>
-          </div>
-        <% end %>
+        <div class="bg-transparent py-1 px-8 text-cyan-500 text-sm rounded-md w-fit">
+          <p>* Click on the name to edit.</p>
+        </div>
 
         <div data-controller="inline-edit">
           <div class="flex flex-row gap-2 items-center">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,33 +1,32 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Incuhive - Organization</title>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= stylesheet_link_tag 'application', media: 'all' %>
-  <%= javascript_include_tag 'application' %>
-</head>
 <body class="bg-gray-100">
 <div class="container">
   <section class="w-full bg-gray-100">
     <div class="bg-gray-800 text-white text-center py-6">
-      <h1 class="text-3xl font-semibold">Organization</h1>
-      <p class="text-lg">Organization Details</p>
+      <h1 class="text-3xl font-semibold">
+        <%= t('organizations.show.heading') %>
+      </h1>
+      <p class="text-lg">
+        <%= t('organizations.show.subheading') %>
+      </p>
     </div>
 
     <div class="flex flex-col items-center gap-4 py-4 text-lg">
       <div class="bg-transparent py-1 px-8 text-cyan-500 text-sm rounded-md w-fit">
-        <p>* Click on the name to edit.</p>
+        <p>
+          <%= t('organizations.show.fields.info_name') %>
+        </p>
       </div>
 
       <div data-controller="inline-edit">
         <div class="flex flex-row gap-2 items-center">
-          <span class="font-bold">Name:</span>
+          <span class="font-bold">
+            <%= t('organizations.show.fields.labels.name') %>
+          </span>
           <span data-inline-edit-target="name" class="editable"><%= @organization.name %></span>
           <%= form_with model: @organization, local: true, data: { inline_edit_target: "form" }, class: "hidden" do |form| %>
             <%= form.text_field :name, data: { inline_edit_target: "input" }, class: "w-[300px] mt-1 rounded-md border-gray-200 shadow-sm sm:text-md py-3" %>
             <%=
-              form.submit "Save",
+              form.submit t('organizations.show.buttons.save_name'),
                           data: { action: "inline-edit#save" },
                           class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-6 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
             %>
@@ -36,13 +35,15 @@
       </div>
 
       <div class="flex flex-row gap-2 items-center">
-        <span class="font-bold">Invite Code:</span>
+        <span class="font-bold">
+          <%= t('organizations.show.fields.labels.invite_code') %>
+        </span>
         <%= @organization.invite_code %>
       </div>
 
       <div>
         <%=
-          button_to "Regenerate Invite Code",
+          button_to t('organizations.show.buttons.regenerate_invite_code'),
                     regenerate_invite_code_organization_path(@organization),
                     method: :patch,
                     class: "cursor-pointer rounded-md border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
@@ -51,12 +52,18 @@
 
       <!-- Panelists Table -->
       <div class="w-full mt-8">
-        <h2 class="text-2xl font-semibold mb-4">Panelists</h2>
+        <h2 class="text-2xl font-semibold mb-4">
+          <%= t('organizations.show.panelists.title') %>
+        </h2>
         <table class="min-w-full bg-white border border-gray-200 rounded-lg shadow-md">
           <thead class="bg-gray-200 text-gray-600">
           <tr>
-            <th class="py-2 px-4 border-b">Email</th>
-            <th class="py-2 px-4 border-b">Created at</th>
+            <th class="py-2 px-4 border-b">
+              <%= t('organizations.show.panelists.columns.email') %>
+            </th>
+            <th class="py-2 px-4 border-b">
+              <%= t('organizations.show.panelists.columns.created_at') %>
+            </th>
           </tr>
           </thead>
           <tbody>
@@ -73,4 +80,3 @@
   </section>
 </div>
 </body>
-</html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,12 @@ en:
       excel_interop_desc: 'Incuhive can both import and export to Excel'
 
   organizations:
+    create_or_join:
+      heading: 'Create or Join an Organization'
+      subheading: 'Enter an invite code to join an organization or create a new one'
+      buttons:
+          join: 'Join'
+          create: 'Create'
     new:
       heading: 'Create Organization'
       subheading: 'Create a new organization'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,52 @@
 
 en:
   hello: "Hello world"
+
+  home:
+    heading: 'Welcome to Incuhive'
+    subheading: 'Streamlining the hiring process for your team'
+    heading_why: 'Why Choose Incuhive?'
+    heading_why_answer: 'Incuhive makes hiring easier with powerful features designed to streamline your hiring process.'
+    signed_in:
+      welcome: 'Welcome back, %{email}!'
+      subheading: 'Here are your organizations'
+      buttons:
+        sign_out: 'Sign out'
+    not_signed_in:
+      buttons:
+        get_started: 'Get Started'
+    benefits:
+      easy_to_use: 'Easy to use'
+      easy_to_use_desc: 'Anyone can use Incuhive, no training necessary'
+      excel_interop: 'Excel Interop'
+      excel_interop_desc: 'Incuhive can both import and export to Excel'
+
+  organizations:
+    new:
+      heading: 'Create Organization'
+      subheading: 'Create a new organization'
+      fields:
+        placeholders:
+          name: 'Name'
+    show:
+      heading: 'Organization'
+      subheading: 'Organization details'
+      fields:
+        info_name: '* Click on the name to edit.'
+        labels:
+          name: 'Name:'
+          invite_code: 'Invite Code:'
+      buttons:
+        save_name: 'Save'
+        regenerate_invite_code: 'Regenerate Invite Code'
+      panelists:
+        title: 'Panelists'
+        columns:
+          email: 'Email'
+          created_at: 'Created At'
+    create:
+      success: "Organization created successfully"
+    update:
+      success: "Organization updated successfully"
+    regenerate_invite_code:
+      success: "Invite code regenerated successfully"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root 'home#index'
   resources :organizations, only: %i[new create show update] do
+    get :create_or_join, on: :collection
     patch :regenerate_invite_code, on: :member
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#index'
-  resources :organizations, only: [:new, :create, :show, :update]
+  resources :organizations, only: [:new, :create, :show, :update] do
+    patch :regenerate_invite_code, on: :member
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#index'
-  resources :organizations, only: [:new, :create, :show, :update] do
+  resources :organizations, only: %i[new create show update] do
     patch :regenerate_invite_code, on: :member
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#index'
-  resources :organizations, only: [:new, :create]
+  resources :organizations, only: [:new, :create, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#index'
-  resources :organizations, only: [:new, :create, :show]
+  resources :organizations, only: [:new, :create, :show, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root 'home#index'
+  resources :organizations, only: [:new, :create]
 end

--- a/db/migrate/20240727075056_create_organizations.rb
+++ b/db/migrate/20240727075056_create_organizations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :organizations do |t|
+      t.string :name, null: false, index: { unique: true }
+      t.string :invite_code, null: false, index: { unique: true }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240727182322_add_organization_to_panelist.rb
+++ b/db/migrate/20240727182322_add_organization_to_panelist.rb
@@ -3,13 +3,5 @@
 class AddOrganizationToPanelist < ActiveRecord::Migration[7.0]
   def change
     add_reference :panelists, :organization, null: true, foreign_key: true
-
-    reversible do |dir|
-      dir.up do
-        # Ensure that all existing panelists are associated with the first organization
-        organization = Organization.find_or_create_by!(name: 'Default Organization')
-        Panelist.update_all(organization_id: organization.id)
-      end
-    end
   end
 end

--- a/db/migrate/20240727182322_add_organization_to_panelist.rb
+++ b/db/migrate/20240727182322_add_organization_to_panelist.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddOrganizationToPanelist < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :panelists, :organization, null: true, foreign_key: true
+
+    reversible do |dir|
+      dir.up do
+        # Ensure that all existing panelists are associated with the first organization
+        organization = Organization.find_or_create_by!(name: 'Default Organization')
+        Panelist.update_all(organization_id: organization.id)
+      end
+    end
+  end
+end

--- a/db/migrate/20240727183048_make_panelist_organization_compulsary.rb
+++ b/db/migrate/20240727183048_make_panelist_organization_compulsary.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakePanelistOrganizationCompulsary < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :panelists, :organization_id, false
+  end
+end

--- a/db/migrate/20240727183048_make_panelist_organization_compulsary.rb
+++ b/db/migrate/20240727183048_make_panelist_organization_compulsary.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class MakePanelistOrganizationCompulsary < ActiveRecord::Migration[7.0]
-  def change
-    change_column_null :panelists, :organization_id, false
-  end
-end

--- a/db/migrate/20240727190039_add_admin_to_organizations.rb
+++ b/db/migrate/20240727190039_add_admin_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdminToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :organizations, :admin, null: true, foreign_key: { to_table: :panelists }
+  end
+end

--- a/db/migrate/20240727190039_add_admin_to_organizations.rb
+++ b/db/migrate/20240727190039_add_admin_to_organizations.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddAdminToOrganizations < ActiveRecord::Migration[7.0]
-  def change
-    add_reference :organizations, :admin, null: true, foreign_key: { to_table: :panelists }
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_27_183048) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_27_190039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_183048) do
     t.string "invite_code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "admin_id"
+    t.index ["admin_id"], name: "index_organizations_on_admin_id"
     t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end
@@ -31,11 +33,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_183048) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "organization_id", null: false
+    t.integer "organization_id"
     t.index ["email"], name: "index_panelists_on_email", unique: true
     t.index ["organization_id"], name: "index_panelists_on_organization_id"
     t.index ["reset_password_token"], name: "index_panelists_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "organizations", "panelists", column: "admin_id"
   add_foreign_key "panelists", "organizations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_27_190039) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_27_182322) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,8 +19,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_190039) do
     t.string "invite_code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "admin_id"
-    t.index ["admin_id"], name: "index_organizations_on_admin_id"
     t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
     t.index ["name"], name: "index_organizations_on_name", unique: true
   end
@@ -39,6 +37,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_190039) do
     t.index ["reset_password_token"], name: "index_panelists_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "organizations", "panelists", column: "admin_id"
   add_foreign_key "panelists", "organizations"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "invite_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
+    t.index ["name"], name: "index_organizations_on_name", unique: true
+  end
+
   create_table "panelists", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -24,15 +33,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_panelists_on_email", unique: true
     t.index ["reset_password_token"], name: "index_panelists_on_reset_password_token", unique: true
-  end
-
-  create_table "organizations", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "invite_code", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
-    t.index ["name"], name: "index_organizations_on_name", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,8 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
-  create_table "organizations", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "invite_code", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
-    t.index ["name"], name: "index_organizations_on_name", unique: true
-  end
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "panelists", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -30,6 +24,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_panelists_on_email", unique: true
     t.index ["reset_password_token"], name: "index_panelists_on_reset_password_token", unique: true
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "invite_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
+    t.index ["name"], name: "index_organizations_on_name", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,4 +26,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
     t.index ["reset_password_token"], name: "index_panelists_on_reset_password_token", unique: true
   end
 
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "invite_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
+    t.index ["name"], name: "index_organizations_on_name", unique: true
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,14 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "invite_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
+    t.index ["name"], name: "index_organizations_on_name", unique: true
+  end
 
   create_table "panelists", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -24,15 +30,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_panelists_on_email", unique: true
     t.index ["reset_password_token"], name: "index_panelists_on_reset_password_token", unique: true
-  end
-
-  create_table "organizations", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "invite_code", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["invite_code"], name: "index_organizations_on_invite_code", unique: true
-    t.index ["name"], name: "index_organizations_on_name", unique: true
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_27_183048) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,8 +31,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_27_092138) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "organization_id", null: false
     t.index ["email"], name: "index_panelists_on_email", unique: true
+    t.index ["organization_id"], name: "index_panelists_on_organization_id"
     t.index ["reset_password_token"], name: "index_panelists_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "panelists", "organizations"
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :organization do
-    name { 'Test Organization' }
-    invite_code { SecureRandom.hex(10) }
+    name { Faker::Company.name }
+    invite_code { SecureRandom.hex(4) }
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :organization do
+    name { 'Test Organization' }
+    invite_code { SecureRandom.hex(10) }
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Organization do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -3,5 +3,61 @@
 require 'rails_helper'
 
 RSpec.describe Organization do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'when creating a new organization in database' do
+    it 'validates the presence of name' do
+      organization = described_class.new
+      expect(organization).not_to be_valid
+      expect(organization.errors[:name]).to include("can't be blank")
+    end
+
+    it 'validates the uniqueness of name' do
+      described_class.create(name: 'Test Organization')
+      organization = described_class.new(name: 'Test Organization')
+      expect(organization).not_to be_valid
+      expect(organization.errors[:name]).to include('has already been taken')
+    end
+
+    it 'generates an invite code' do
+      organization = described_class.create(name: 'Test Organization')
+      expect(organization.invite_code).to be_present
+    end
+
+    it 'generates a unique invite code' do
+      organization1 = described_class.create(name: 'Test Organization 1')
+      organization2 = described_class.create(name: 'Test Organization 2', invite_code: organization1.invite_code)
+      expect(organization1.invite_code).not_to eq(organization2.invite_code)
+    end
+  end
+
+  context 'when creating new organization instance' do
+    it 'does not generate invite code during initialization' do
+      organization = described_class.new(name: 'Test Organization')
+      expect(organization.invite_code).to be_nil
+    end
+
+    it 'generates an invite code when validating' do
+      organization = described_class.new(name: 'Test Organization')
+      expect(organization).to be_valid
+      expect(organization.invite_code).to be_present
+    end
+
+    it 'regenerates an invite code if it is not unique' do
+      organization1 = described_class.create(name: 'Test Organization 1')
+      organization2 = described_class.new(name: 'Test Organization 2', invite_code: organization1.invite_code)
+
+      expect(organization2).to be_valid
+
+      expect(organization2.invite_code).not_to eq(organization1.invite_code)
+    end
+  end
+
+  context 'when regenerating invite code' do
+    it 'assigns a random invite code' do
+      organization = described_class.create(name: 'Test Organization')
+      initial_invite_code = organization.invite_code
+      organization.regenerate_invite_code
+
+      expect(organization.invite_code).not_to eq(initial_invite_code)
+    end
+  end
 end

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -96,5 +96,12 @@ RSpec.describe 'Organizations' do
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    describe 'GET /organizations/create_or_join' do
+      it 'renders the create_or_join template' do
+        get create_or_join_organizations_path
+        expect(response.body).to include('Create or Join Organization')
+      end
+    end
   end
 end

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -2,8 +2,85 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Organizations' do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
+RSpec.describe 'Organizations', type: :request do
+  let(:organization) { create(:organization) }
+
+  describe 'GET /organizations/:id' do
+    it 'renders the show template' do
+      get organization_path(organization)
+      expect(response.body).to include('Show Organization')
+    end
+
+    it 'handles non-existent organization' do
+      expect do
+        get organization_path(id: 'non-existent-id')
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe 'GET /organizations/new' do
+    it 'renders the new template' do
+      get new_organization_path
+      expect(response.body).to include('Create Organization')
+    end
+  end
+
+  describe 'POST /organizations' do
+    it 'creates a new organization successfully' do
+      post organizations_path, params: { organization: { name: 'New Organization' } }
+      expect(response).to redirect_to(new_organization_path)
+      follow_redirect!
+      expect(response.body).to include('Organization created successfully.')
+      expect(Organization.last.name).to eq('New Organization')
+    end
+
+    it 'handles non-unique organization name on create' do
+      create(:organization, name: 'Existing Name')
+      post organizations_path, params: { organization: { name: 'Existing Name' } }
+      expect(response).to redirect_to(new_organization_path)
+      follow_redirect!
+      expect(response.body).to include('Organization name must be unique.')
+    end
+  end
+
+  describe 'PATCH /organizations/:id' do
+    it 'updates the organization name successfully' do
+      patch organization_path(organization), params: { organization: { name: 'New Name' } }
+      expect(response).to redirect_to(organization_path(organization))
+      follow_redirect!
+      expect(response.body).to include('Organization updated successfully.')
+      expect(organization.reload.name).to eq('New Name')
+    end
+
+    it 'handles non-unique organization name' do
+      create(:organization, name: 'Existing Name')
+      patch organization_path(organization), params: { organization: { name: 'Existing Name' } }
+      expect(response).to redirect_to(organization_path(organization))
+      follow_redirect!
+      expect(response.body).to include('Organization name must be unique.')
+    end
+
+    it 'handles non-existent organization' do
+      expect do
+        patch organization_path(id: 'non-existent-id'), params: { organization: { name: 'New Name' } }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe 'PATCH /organizations/:id/regenerate_invite_code' do
+    it 'regenerates the invite code successfully' do
+      old_invite_code = organization.invite_code
+      patch regenerate_invite_code_organization_path(organization)
+      expect(response).to redirect_to(organization_path(organization))
+      follow_redirect!
+      expect(response.body).to include('Invite code regenerated successfully.')
+      expect(organization.reload.invite_code).not_to eq(old_invite_code)
+    end
+
+    it 'handles non-existent organization' do
+      expect do
+        patch regenerate_invite_code_organization_path(id: 'non-existent-id')
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
   end
 end

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Organizations' do
   describe 'POST /organizations' do
     it 'creates a new organization successfully' do
       post organizations_path, params: { organization: { name: 'New Organization' } }
-      expect(response).to redirect_to(new_organization_path)
+      expect(response).to redirect_to(organization_path(Organization.last))
       follow_redirect!
       expect(response.body).to include('Organization created successfully.')
       expect(Organization.last.name).to eq('New Organization')

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -39,9 +39,13 @@ RSpec.describe 'Organizations' do
     end
 
     describe 'POST /organizations' do
-      it 'creates a new organization successfully' do
+      it 'redirects to organization show page on success' do
         post organizations_path, params: { organization: { name: 'New Organization' } }
         expect(response).to redirect_to(organization_path(Organization.last))
+      end
+
+      it 'creates a new organization successfully' do
+        post organizations_path, params: { organization: { name: 'New Organization' } }
         follow_redirect!
         expect(response.body).to include('Organization created successfully')
         expect(Organization.last.name).to eq('New Organization')
@@ -57,9 +61,13 @@ RSpec.describe 'Organizations' do
     end
 
     describe 'PATCH /organizations/:id' do
-      it 'updates the organization name successfully' do
+      it 'redirects to organization show page on success' do
         patch organization_path(organization), params: { organization: { name: 'New Name' } }
         expect(response).to redirect_to(organization_path(organization))
+      end
+
+      it 'updates the organization name successfully' do
+        patch organization_path(organization), params: { organization: { name: 'New Name' } }
         follow_redirect!
         expect(response.body).to include('Organization updated successfully')
         expect(organization.reload.name).to eq('New Name')
@@ -81,10 +89,14 @@ RSpec.describe 'Organizations' do
     end
 
     describe 'PATCH /organizations/:id/regenerate_invite_code' do
+      it 'redirects to organization show page on success' do
+        patch regenerate_invite_code_organization_path(organization)
+        expect(response).to redirect_to(organization_path(organization))
+      end
+
       it 'regenerates the invite code successfully' do
         old_invite_code = organization.invite_code
         patch regenerate_invite_code_organization_path(organization)
-        expect(response).to redirect_to(organization_path(organization))
         follow_redirect!
         expect(response.body).to include('Invite code regenerated successfully')
         expect(organization.reload.invite_code).not_to eq(old_invite_code)
@@ -100,7 +112,7 @@ RSpec.describe 'Organizations' do
     describe 'GET /organizations/create_or_join' do
       it 'renders the create_or_join template' do
         get create_or_join_organizations_path
-        expect(response.body).to include('Create or Join Organization')
+        expect(response.body).to include('Create or Join an Organization')
       end
     end
   end

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -3,84 +3,98 @@
 require 'rails_helper'
 
 RSpec.describe 'Organizations' do
-  let(:organization) { create(:organization) }
-
-  describe 'GET /organizations/:id' do
-    it 'renders the show template' do
-      get organization_path(organization)
-      expect(response.body).to include('Organization Details')
-    end
-
-    it 'handles non-existent organization' do
-      expect do
-        get organization_path(id: 'non-existent-id')
-      end.to raise_error(ActiveRecord::RecordNotFound)
-    end
-  end
-
-  describe 'GET /organizations/new' do
-    it 'renders the new template' do
+  context 'when not authenticated' do
+    it 'redirects to the sign-in page' do
       get new_organization_path
-      expect(response.body).to include('Create Organization')
+      expect(response).to redirect_to(new_panelist_session_path)
     end
   end
 
-  describe 'POST /organizations' do
-    it 'creates a new organization successfully' do
-      post organizations_path, params: { organization: { name: 'New Organization' } }
-      expect(response).to redirect_to(organization_path(Organization.last))
-      follow_redirect!
-      expect(response.body).to include('Organization created successfully.')
-      expect(Organization.last.name).to eq('New Organization')
+  context 'when authenticated' do
+    let(:panelist) { create(:panelist) }
+    let(:organization) { create(:organization) }
+
+    before do
+      sign_in panelist
     end
 
-    it 'handles non-unique organization name on create' do
-      create(:organization, name: 'Existing Name')
-      post organizations_path, params: { organization: { name: 'Existing Name' } }
-      expect(response).to redirect_to(new_organization_path)
-      follow_redirect!
-      expect(response.body).to include('Name has already been taken')
-    end
-  end
+    describe 'GET /organizations/:id' do
+      it 'renders the show template' do
+        get organization_path(organization)
+        expect(response.body).to include('Organization details')
+      end
 
-  describe 'PATCH /organizations/:id' do
-    it 'updates the organization name successfully' do
-      patch organization_path(organization), params: { organization: { name: 'New Name' } }
-      expect(response).to redirect_to(organization_path(organization))
-      follow_redirect!
-      expect(response.body).to include('Organization updated successfully.')
-      expect(organization.reload.name).to eq('New Name')
+      it 'handles non-existent organization' do
+        expect do
+          get organization_path(id: 'non-existent-id')
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
-    it 'handles non-unique organization name' do
-      create(:organization, name: 'Existing Name')
-      patch organization_path(organization), params: { organization: { name: 'Existing Name' } }
-      expect(response).to redirect_to(organization_path(organization))
-      follow_redirect!
-      expect(response.body).to include('Name has already been taken')
+    describe 'GET /organizations/new' do
+      it 'renders the new template' do
+        get new_organization_path
+        expect(response.body).to include('Create Organization')
+      end
     end
 
-    it 'handles non-existent organization' do
-      expect do
-        patch organization_path(id: 'non-existent-id'), params: { organization: { name: 'New Name' } }
-      end.to raise_error(ActiveRecord::RecordNotFound)
-    end
-  end
+    describe 'POST /organizations' do
+      it 'creates a new organization successfully' do
+        post organizations_path, params: { organization: { name: 'New Organization' } }
+        expect(response).to redirect_to(organization_path(Organization.last))
+        follow_redirect!
+        expect(response.body).to include('Organization created successfully')
+        expect(Organization.last.name).to eq('New Organization')
+      end
 
-  describe 'PATCH /organizations/:id/regenerate_invite_code' do
-    it 'regenerates the invite code successfully' do
-      old_invite_code = organization.invite_code
-      patch regenerate_invite_code_organization_path(organization)
-      expect(response).to redirect_to(organization_path(organization))
-      follow_redirect!
-      expect(response.body).to include('Invite code regenerated successfully.')
-      expect(organization.reload.invite_code).not_to eq(old_invite_code)
+      it 'handles non-unique organization name on create' do
+        create(:organization, name: 'Existing Name')
+        post organizations_path, params: { organization: { name: 'Existing Name' } }
+        expect(response).to redirect_to(new_organization_path)
+        follow_redirect!
+        expect(response.body).to include('Name has already been taken')
+      end
     end
 
-    it 'handles non-existent organization' do
-      expect do
-        patch regenerate_invite_code_organization_path(id: 'non-existent-id')
-      end.to raise_error(ActiveRecord::RecordNotFound)
+    describe 'PATCH /organizations/:id' do
+      it 'updates the organization name successfully' do
+        patch organization_path(organization), params: { organization: { name: 'New Name' } }
+        expect(response).to redirect_to(organization_path(organization))
+        follow_redirect!
+        expect(response.body).to include('Organization updated successfully')
+        expect(organization.reload.name).to eq('New Name')
+      end
+
+      it 'handles non-unique organization name' do
+        create(:organization, name: 'Existing Name')
+        patch organization_path(organization), params: { organization: { name: 'Existing Name' } }
+        expect(response).to redirect_to(organization_path(organization))
+        follow_redirect!
+        expect(response.body).to include('Name has already been taken')
+      end
+
+      it 'handles non-existent organization' do
+        expect do
+          patch organization_path(id: 'non-existent-id'), params: { organization: { name: 'New Name' } }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    describe 'PATCH /organizations/:id/regenerate_invite_code' do
+      it 'regenerates the invite code successfully' do
+        old_invite_code = organization.invite_code
+        patch regenerate_invite_code_organization_path(organization)
+        expect(response).to redirect_to(organization_path(organization))
+        follow_redirect!
+        expect(response.body).to include('Invite code regenerated successfully')
+        expect(organization.reload.invite_code).not_to eq(old_invite_code)
+      end
+
+      it 'handles non-existent organization' do
+        expect do
+          patch regenerate_invite_code_organization_path(id: 'non-existent-id')
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Organizations' do
+  describe 'GET /index' do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/organizations_spec.rb
+++ b/spec/requests/organizations_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Organizations', type: :request do
+RSpec.describe 'Organizations' do
   let(:organization) { create(:organization) }
 
   describe 'GET /organizations/:id' do
     it 'renders the show template' do
       get organization_path(organization)
-      expect(response.body).to include('Show Organization')
+      expect(response.body).to include('Organization Details')
     end
 
     it 'handles non-existent organization' do
@@ -39,7 +39,7 @@ RSpec.describe 'Organizations', type: :request do
       post organizations_path, params: { organization: { name: 'Existing Name' } }
       expect(response).to redirect_to(new_organization_path)
       follow_redirect!
-      expect(response.body).to include('Organization name must be unique.')
+      expect(response.body).to include('Name has already been taken')
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe 'Organizations', type: :request do
       patch organization_path(organization), params: { organization: { name: 'Existing Name' } }
       expect(response).to redirect_to(organization_path(organization))
       follow_redirect!
-      expect(response.body).to include('Organization name must be unique.')
+      expect(response.body).to include('Name has already been taken')
     end
 
     it 'handles non-existent organization' do

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'home/index.html.erb' do
     end
 
     it 'greets the signed-in panelist' do
-      expect(rendered).to have_content('Welcome test@example.com')
+      expect(rendered).to have_content('Welcome back, test@example.com!')
     end
 
     it 'shows the sign out button' do


### PR DESCRIPTION
## What did you do?

- [x] Add organization resources (migration, model)
- [x] Add pages to create and show and edit organization. After creating org, it redirects to its show page
    - [x] The edit page can change name of org by clicking on it and can regenerate invite code of 8 characters
- [x] Relate panelists and organization through foreign key and associations
- [x] Make sure all organizations have a single panelist who is an admin 
- [x] In the show page, show list of all panelists
- [ ] Only admin should be able to create organization??? <- decide this
- [ ] Only admin panelist should be able to edit the organization
    - [ ] For adding a `admin` role into the system, we should first rename panelist to `user` for a better terminology
    - [ ] then we should add `admin_id` to organization table
    - [ ] need to fig out how to handle interdependency - panelist require org id and org required admin_id (which in turn is panelist). Need to solve this. 
- [ ] Only users of the organization should be able to view their page
- misc: https://bhartee-tech-ror.medium.com/creating-a-rails-7-application-with-devise-and-roles-15fdac91ebd4

## Why did you do it?

## Screenshots (Please include if anything visual)

Include any relevant screenshots that may help explain the change.
